### PR TITLE
fix: bump flask version for the pre-built image

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,3 +1,3 @@
-python-dotenv==0.15.0
-Flask==1.1.2
-Redis==3.5.3
+python-dotenv==0.20.0
+flask==2.1.0
+redis==4.3.1

--- a/docs/docs/lab-docker-run.md
+++ b/docs/docs/lab-docker-run.md
@@ -26,7 +26,7 @@ docker run -p 80:8080 ghcr.io/piperjapan/p4app:0.0.1
 
 [![image](https://user-images.githubusercontent.com/2920259/98806878-2f5b4080-245d-11eb-9cfa-4a8e9b396a2d.png)](https://user-images.githubusercontent.com/2920259/98806878-2f5b4080-245d-11eb-9cfa-4a8e9b396a2d.png)
 
-コマンドの実行後、なにやら処理が行われ、`[ Running on http://0.0.0.0:8080/ (Press CTRL+C to quit) ]` の表示を確認したら、GCP の管理コンソールに戻って、操作している仮想マシンの `[ 外部 IP ]` をクリックします。これは、HTTP でその IP アドレスにアクセスできるリンクです。
+コマンドの実行後、なにやら処理が行われ、`[ Running on http://x.x.x.x:8080/ (Press CTRL+C to quit) ]` の表示を確認したら、GCP の管理コンソールに戻って、操作している仮想マシンの `[ 外部 IP ]` をクリックします。これは、HTTP でその IP アドレスにアクセスできるリンクです。
 
 [![image](https://user-images.githubusercontent.com/2920259/98807136-8f51e700-245d-11eb-92ce-ab92327a75a9.png)](https://user-images.githubusercontent.com/2920259/98807136-8f51e700-245d-11eb-92ce-ab92327a75a9.png)
 

--- a/lab-docker-build/requirements.txt
+++ b/lab-docker-build/requirements.txt
@@ -1,3 +1,3 @@
-python-dotenv==0.15.0
-Flask==2.1.0
-Redis==3.5.3
+python-dotenv==0.20.0
+flask==2.1.0
+redis==4.3.1


### PR DESCRIPTION
- #4 で修正いただいた Flask バージョンを、ラボ中で利用するビルド済みイメージ（`ghcr.io/piperjapan/p4app:0.0.1`）にも反映 
 - タグはいったんそのまま
 - 本来はパッチレベルを上げてガイドも直すべきだけれど、全体のスケジュール感を把握していないので変更影響を抑える方向で判断
- 併せてほかのパッケージも最新化
- Flask のバージョンアップで画面の出力が若干変更されているので、ラボの文字列を微修正
