### PR TITLE
revert: remove apt command on centos-based image (7d80abb)

### DIFF
--- a/docs/docs/lab-docker-shell.md
+++ b/docs/docs/lab-docker-shell.md
@@ -62,7 +62,6 @@ docker run --rm -it quay.io/centos/centos:stream8 bash
 
 ```bash
 cat /etc/os-release
-apt update
 dnf install -y python38
 python3 -c 'print("hello world")'
 ```


### PR DESCRIPTION
#5 がマージされたことで残ってしまった Ubuntu 用の `apt` コマンドを削除