### PR TITLE
fix: bump mkdocs version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.1.2
-mkdocs-material==7.1.4
+wheel==0.37.1
+mkdocs==1.3.0
+mkdocs-material==8.2.16
 fontawesome-markdown==0.2.6
-pymdown-extensions==8.2


### PR DESCRIPTION
`requirements.txt` で指定しているパッケージが古く、ビルドに失敗する問題の修正。

Closes #7